### PR TITLE
Export LanguageBadge

### DIFF
--- a/src/badges/index.ts
+++ b/src/badges/index.ts
@@ -7,3 +7,4 @@ const resolver = (props: IResolverProps) => {
 }
 
 export default resolver;
+export { LanguageBadge };


### PR DESCRIPTION
Right now only the resolver function is exported from the badges module which means it can't be used with other custom badges.

Export the `LanguageBadge` function so it can be imported in our own badge resolver function.