### PR TITLE
support a function to get available languages

### DIFF
--- a/src/actions/DeleteWithi18nAction.tsx
+++ b/src/actions/DeleteWithi18nAction.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
-import defaultResolve, { DeleteAction } from 'part:@sanity/base/document-actions'
 import ConfirmDelete from '@sanity/desk-tool/lib/components/ConfirmDelete';
 import TrashIcon from 'part:@sanity/base/trash-icon'
 import { IResolverProps, IUseDocumentOperationResult } from '../types';
-import { getConfig, getSanityClient, getBaseIdFromId, buildDocId, getTranslationsFor } from '../utils';
+import { getConfig, getSanityClient, getBaseIdFromId, getTranslationsFor } from '../utils';
 import { useDocumentOperation } from '@sanity/react-hooks';
-import { SanityDocument } from '@sanity/client';
-import { I18nPrefix } from '../constants';
 
 /**
  * This code is mostly taken from the defualt DeleteAction provided by Sanity

--- a/src/actions/PublishWithi18nAction.ts
+++ b/src/actions/PublishWithi18nAction.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import moment, { lang } from 'moment';
-import { SanityDocument, Patch } from '@sanity/client';
+import moment from 'moment';
 import { IResolverProps, Ti18nSchema, IUseDocumentOperationResult } from '../types';
 import { useDocumentOperation, useSyncState } from '@sanity/react-hooks';
 import {
@@ -41,7 +40,7 @@ export const PublishWithi18nAction = (props: IResolverProps) => {
       const client = getSanityClient();
       const fieldName = config.fieldNames.lang;
       const refsFieldName = config.fieldNames.references;
-      const langs = await getLanguagesFromOption(config.languages);
+      const langs = await getLanguagesFromOption(config.languages, props);
       const languageId = getLanguageFromId(props.id) || getBaseLanguage(langs, config.base)?.name;
 
       await client.createIfNotExists({ _id: props.id, _type: props.type, _createdAt: moment().utc().toISOString() });

--- a/src/actions/PublishWithi18nAction.ts
+++ b/src/actions/PublishWithi18nAction.ts
@@ -10,7 +10,6 @@ import {
   getBaseIdFromId,
   getSanityClient,
   getConfig,
-  buildDocId,
   getTranslationsFor,
 } from '../utils';
 import { ReferenceBehavior } from '../constants';
@@ -40,8 +39,8 @@ export const PublishWithi18nAction = (props: IResolverProps) => {
       const client = getSanityClient();
       const fieldName = config.fieldNames.lang;
       const refsFieldName = config.fieldNames.references;
-      const langs = await getLanguagesFromOption(config.languages, props);
-      const languageId = getLanguageFromId(props.id) || getBaseLanguage(langs, config.base)?.name;
+      const langs = await getLanguagesFromOption(config.languages, props.draft || props.published);
+      const languageId = getLanguageFromId(props.id) || getBaseLanguage(langs, typeof config.base === 'function' ? config.base(props.draft || props.published) : config.base)?.name;
 
       await client.createIfNotExists({ _id: props.id, _type: props.type, _createdAt: moment().utc().toISOString() });
       await client.patch(props.draft?._id || props.id, { set: { [fieldName]: languageId } }).commit();

--- a/src/input/index.tsx
+++ b/src/input/index.tsx
@@ -46,6 +46,7 @@ class Input extends React.PureComponent<IProps, IState> {
     const { type: { type, options } } = this.props;
     const config = getConfig(type);
     const { languages } = this.state;
+    // TODO: can we get document here (could possibly fetch it with the client)
     return getBaseLanguage(langs || languages, options.base || config.base);
   }
 
@@ -149,7 +150,8 @@ class Input extends React.PureComponent<IProps, IState> {
     const { type: { type, options } } = this.props;
     const config = getConfig(type);
     this.setState({ fetchingLanguages: true });
-    const languages: IState['languages'] = await getLanguagesFromOption(options.languages || config.languages, this.props);
+    // TODO: can we get document here
+    const languages: IState['languages'] = await getLanguagesFromOption(options.languages || config.languages, this.props.document);
     this.setState({
       languages,
       currentLanguage: this.getBaseLanguage(languages),

--- a/src/input/index.tsx
+++ b/src/input/index.tsx
@@ -149,7 +149,7 @@ class Input extends React.PureComponent<IProps, IState> {
     const { type: { type, options } } = this.props;
     const config = getConfig(type);
     this.setState({ fetchingLanguages: true });
-    const languages: IState['languages'] = await getLanguagesFromOption(options.languages || config.languages);
+    const languages: IState['languages'] = await getLanguagesFromOption(options.languages || config.languages, this.props);
     this.setState({
       languages,
       currentLanguage: this.getBaseLanguage(languages),

--- a/src/structure/IDefaultDocumentNodeStructureProps.ts
+++ b/src/structure/IDefaultDocumentNodeStructureProps.ts
@@ -1,4 +1,5 @@
 export interface IDefaultDocumentNodeStructureProps {
     documentId: string;
+    document: object;
     schemaType: string;
 }

--- a/src/structure/TranslationsComponentFactory/TranslationsComponentFactory.tsx
+++ b/src/structure/TranslationsComponentFactory/TranslationsComponentFactory.tsx
@@ -10,15 +10,15 @@ export const TranslationsComponentFactory = (schema: Ti18nSchema) => (props: IDe
   const [pending, setPending] = React.useState(false);
   const [languages, setLanguages] = React.useState<ILanguageObject[]>([]);
   const [baseDocument, setBaseDocument] = React.useState(null);
-  const [baseLanguage, setBaseLanguage] = React.useState(null);
+  const [baseLanguage, setBaseLanguage] = React.useState<ILanguageObject | null>(null);
 
   React.useEffect(
     () => {
       (async () => {
         setPending(true);
         const doc = await getSanityClient().fetch('*[_id == $id]', { id: getBaseIdFromId(props.documentId) });
-        const langs = await getLanguagesFromOption(config.languages, doc);
-        const baseLang = getBaseLanguage(languages, typeof config.base === 'function' ? config.base(doc) : config.base);
+        const langs = await getLanguagesFromOption(config.languages, props.documentId);
+        const baseLang = getBaseLanguage(languages, typeof config.base === 'function' ? config.base(props.document) : config.base);
         if (doc && doc.length > 0) setBaseDocument(doc[0]);
         setLanguages(langs);
         setBaseLanguage(baseLang);

--- a/src/structure/TranslationsComponentFactory/TranslationsComponentFactory.tsx
+++ b/src/structure/TranslationsComponentFactory/TranslationsComponentFactory.tsx
@@ -15,8 +15,8 @@ export const TranslationsComponentFactory = (schema: Ti18nSchema) => (props: IDe
     () => {
       (async () => {
         setPending(true);
-        const langs = await getLanguagesFromOption(config.languages);
         const doc = await getSanityClient().fetch('*[_id == $id]', { id: getBaseIdFromId(props.documentId) });
+        const langs = await getLanguagesFromOption(config.languages, doc);
         if (doc && doc.length > 0) setBaseDocument(doc[0]);
         setLanguages(langs);
         setPending(false);

--- a/src/structure/TranslationsComponentFactory/TranslationsComponentFactory.tsx
+++ b/src/structure/TranslationsComponentFactory/TranslationsComponentFactory.tsx
@@ -10,6 +10,7 @@ export const TranslationsComponentFactory = (schema: Ti18nSchema) => (props: IDe
   const [pending, setPending] = React.useState(false);
   const [languages, setLanguages] = React.useState<ILanguageObject[]>([]);
   const [baseDocument, setBaseDocument] = React.useState(null);
+  const [baseLanguage, setBaseLanguage] = React.useState(null);
 
   React.useEffect(
     () => {
@@ -17,8 +18,10 @@ export const TranslationsComponentFactory = (schema: Ti18nSchema) => (props: IDe
         setPending(true);
         const doc = await getSanityClient().fetch('*[_id == $id]', { id: getBaseIdFromId(props.documentId) });
         const langs = await getLanguagesFromOption(config.languages, doc);
+        const baseLang = getBaseLanguage(languages, typeof config.base === 'function' ? config.base(doc) : config.base);
         if (doc && doc.length > 0) setBaseDocument(doc[0]);
         setLanguages(langs);
+        setBaseLanguage(baseLang);
         setPending(false);
       })();
     },
@@ -34,7 +37,6 @@ export const TranslationsComponentFactory = (schema: Ti18nSchema) => (props: IDe
   }
 
   const docId = getBaseIdFromId(props.documentId);
-  const baseLanguage = getBaseLanguage(languages, config.base);
   const currentLanguage = getLanguageFromId(props.documentId) || (baseLanguage ? baseLanguage.name : null);
   return languages.map((lang, index) => (
     <TranslationLink

--- a/src/types/TLanguagesOption.ts
+++ b/src/types/TLanguagesOption.ts
@@ -1,4 +1,4 @@
 import { ILanguageQuery } from './ILanguageQuery';
 import { ILanguageObject } from './ILanguageObject';
 
-export type TLanguagesOption = (string | ILanguageObject)[] | ILanguageQuery;
+export type TLanguagesOption = (string | ILanguageObject)[] | ILanguageQuery | ((lang: any) => string[]);

--- a/src/types/TLanguagesOption.ts
+++ b/src/types/TLanguagesOption.ts
@@ -1,4 +1,4 @@
 import { ILanguageQuery } from './ILanguageQuery';
 import { ILanguageObject } from './ILanguageObject';
 
-export type TLanguagesOption = (string | ILanguageObject)[] | ILanguageQuery | ((lang: any) => string[]);
+export type TLanguagesOption = (string | ILanguageObject)[] | ILanguageQuery | ((doc: object) => (string | ILanguageObject)[]);

--- a/src/types/Ti18nConfig.ts
+++ b/src/types/Ti18nConfig.ts
@@ -4,7 +4,7 @@ import { TFieldNamesConfig } from './TFieldNamesConfig';
 import { IdStructure, ReferenceBehavior } from '../constants';
 
 export type Ti18nConfig = {
-  base?: string;
+  base?: string | ((doc: object) => string);
   languages?: TLanguagesOption;
   idStructure?: IdStructure;
   referenceBehavior?: ReferenceBehavior;

--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -1,6 +1,6 @@
 import config from 'config:intl-input';
 import { getSchema } from './getSchema';
-import { Ti18nSchema, Ti18nConfig, TLanguagesOption, TMessagesConfig, TFieldNamesConfig } from '../types';
+import { Ti18nSchema, Ti18nConfig } from '../types';
 import { IdStructure, ReferenceBehavior } from '../constants';
 
 export function getConfig(type?: string | Ti18nSchema): Required<{

--- a/src/utils/getLanguagesFromOption.ts
+++ b/src/utils/getLanguagesFromOption.ts
@@ -3,9 +3,11 @@ import { TLanguagesOption } from '../types';
 import { normalizeLanguageList } from './normalizeLanguageList';
 import { getSanityClient } from './getSanityClient';
 
-export const getLanguagesFromOption = async (langs: TLanguagesOption) => {
+export const getLanguagesFromOption = async (langs: TLanguagesOption, doc) => {
+  console.log(doc);
   return normalizeLanguageList(await (async () => {
     if (Array.isArray(langs)) return langs;
+    if (typeof langs === 'function') langs(doc);
     const r = await getSanityClient().fetch(langs.query);
     const value = langs.value;
 

--- a/src/utils/getLanguagesFromOption.ts
+++ b/src/utils/getLanguagesFromOption.ts
@@ -6,7 +6,7 @@ import { getSanityClient } from './getSanityClient';
 export const getLanguagesFromOption = async (langs: TLanguagesOption, doc) => {
   return normalizeLanguageList(await (async () => {
     if (Array.isArray(langs)) return langs;
-    if (typeof langs === 'function') langs(doc);
+    else if (typeof langs === 'function') return langs(doc);
     const r = await getSanityClient().fetch(langs.query);
     const value = langs.value;
 

--- a/src/utils/getLanguagesFromOption.ts
+++ b/src/utils/getLanguagesFromOption.ts
@@ -4,7 +4,6 @@ import { normalizeLanguageList } from './normalizeLanguageList';
 import { getSanityClient } from './getSanityClient';
 
 export const getLanguagesFromOption = async (langs: TLanguagesOption, doc) => {
-  console.log(doc);
   return normalizeLanguageList(await (async () => {
     if (Array.isArray(langs)) return langs;
     if (typeof langs === 'function') langs(doc);


### PR DESCRIPTION
This acts as a proposal, currently we can only pass in a `SanityQuery` to react to a languages document or give a static set of values.

In our content we need to React to the region a document is defined in, think about a document being defined in the US, in that case we'll define `['en', 'es']` as languages while if it's another region we'll define a different set of languages, WDYT?

As an example:

```js
export default {
    type: 'document',
    name: '...',
    title: '...',
    fields: [{
        name: '...',
        title: '...',
        type: 'object',
        options: {
            i18n: true,
            base: (doc) => doc.region === 'us' ? 'en_US' :  '',
            languages: doc.region === 'us' ? ['en_US']: ['nl_NL'],
        },
        fields: []
    }]
}

```