### PR TITLE
Enable an option to show/hide country flags

### DIFF
--- a/docs/general-configuration.md
+++ b/docs/general-configuration.md
@@ -31,3 +31,4 @@ Below are all available configuration options.
       * `orphanDocuments`: Defaults to `orphaned translation document(s)`
       * `referenceBehaviorMismatch`: Defaults to `document(s) with mismatched reference behaviors`
       * `fix`: Defaults to `Fix`
+* `showCountryFlags`: Show or hide the country flags. Defaults to `true`.

--- a/src/structure/components/TranslationLink/TranslationLink.tsx
+++ b/src/structure/components/TranslationLink/TranslationLink.tsx
@@ -95,33 +95,35 @@ export const TranslationLink: React.FunctionComponent<IProps> = ({
           style={{ width: `100%` }}
         >
           <Flex align="center" gap={4}>
-            <Box>
-              {codeCountry && codeLanguage && (
-                <Flex
-                  direction="column"
-                  paddingBottom={3}
-                  paddingRight={3}
-                  style={{ position: "relative" }}
-                >
-                  <Heading size={4}>
-                    <FlagComponent code={codeCountry} />
-                  </Heading>
-                  <Heading
-                    size={4}
-                    style={{ position: "absolute", bottom: 0, right: 0 }}
+            {config.showCountryFlags && (
+              <Box>
+                {codeCountry && codeLanguage && (
+                  <Flex
+                    direction="column"
+                    paddingBottom={3}
+                    paddingRight={3}
+                    style={{ position: "relative" }}
                   >
-                    <FlagComponent code={codeLanguage} />
-                  </Heading>
-                </Flex>
-              )}
-              {!codeCountry && codeLanguage && (
-                <Box paddingX={1}>
-                  <Heading size={5}>
-                    <FlagComponent code={codeLanguage} />
-                  </Heading>
-                </Box>
-              )}
-            </Box>
+                    <Heading size={4}>
+                      <FlagComponent code={codeCountry} />
+                    </Heading>
+                    <Heading
+                      size={4}
+                      style={{ position: "absolute", bottom: 0, right: 0 }}
+                    >
+                      <FlagComponent code={codeLanguage} />
+                    </Heading>
+                  </Flex>
+                )}
+                {!codeCountry && codeLanguage && (
+                  <Box paddingX={1}>
+                    <Heading size={5}>
+                      <FlagComponent code={codeLanguage} />
+                    </Heading>
+                  </Box>
+                )}
+              </Box>
+            )}
             <Box flex={1}>
               <Stack space={2}>
                 <Text>{lang.title}</Text>

--- a/src/types/Ti18nConfig.ts
+++ b/src/types/Ti18nConfig.ts
@@ -10,4 +10,5 @@ export type Ti18nConfig = {
   referenceBehavior?: ReferenceBehavior;
   fieldNames?: TFieldNamesConfig;
   messages?: TMessagesConfig;
+  showCountryFlags?: boolean;
 }

--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -26,6 +26,7 @@ export function getConfig(type?: string | Ti18nSchema): Required<{
       references: schema?.fieldNames?.references || cfg?.fieldNames?.references || '__i18n_refs',
     },
     languages: schema?.languages || cfg?.languages || [],
+    showCountryFlags: cfg.showCountryFlags ?? true,
     messages: {
       publishing: schema?.messages?.publishing || cfg?.messages?.publishing || 'Publishing...',
       publish: schema?.messages?.publish || cfg?.messages?.publish || 'Publish',


### PR DESCRIPTION
What's changing?

- Added an option to show/hide the country flags via the configuration

Why?

There's a few reasons:

- The country flag service is broken (#114)
- Countries not always represent a single language/locale
- There are issues when a _locale_ code is used to represent a _country_. e.g. `ar` is the [ISO code for Arabic](https://www.loc.gov/standards/iso639-2/php/code_list.php) while it's also the [ISO code for Argentina](https://www.ncbi.nlm.nih.gov/books/NBK7249/)

<img width="262" alt="Screenshot 2022-02-22 at 13 50 02" src="https://user-images.githubusercontent.com/4297022/155214850-2f78abc0-649a-4dd7-90e5-ce2b064a83d4.png">

Are there breaking changes?

Hopefully not. In order to change the behavior, it requires the consumers to override the default configuration. In this way, it's enabling changes while keeping backwards compatibility.

