### PR TITLE
Fix #124 – Use refactored @sanity/desk-tool `ConfirmDeleteDialog` to avoid crash in v2.28.0

### DIFF
--- a/src/actions/DeleteWithi18nAction.tsx
+++ b/src/actions/DeleteWithi18nAction.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import TrashIcon from 'part:@sanity/base/trash-icon'
-import * as ConfirmDeleteModule from '@sanity/desk-tool/lib/components/ConfirmDelete';
+import * as ConfirmDeleteModule from '@sanity/desk-tool/lib/components/confirmDeleteDialog';
 import { IResolverProps, IUseDocumentOperationResult } from '../types';
 import { getConfig, getSanityClient, getBaseIdFromId, getTranslationsFor } from '../utils';
 import { useDocumentOperation } from '@sanity/react-hooks';
@@ -16,8 +16,8 @@ const DISABLED_REASON_TITLE = {
 
 export const DeleteWithi18nAction = ({ id, type, draft, published, onComplete }: IResolverProps) => {
   const toast = useToast();
-  const ConfirmDelete = React.useMemo(() => (
-    ConfirmDeleteModule?.ConfirmDelete ?? ConfirmDeleteModule?.default
+  const ConfirmDeleteDialog = React.useMemo(() => (
+    ConfirmDeleteModule?.ConfirmDeleteDialog ?? ConfirmDeleteModule?.default
   ), [ConfirmDeleteModule]);
   const config = React.useMemo(() => getConfig(type), [type]);
   const baseDocumentId = React.useMemo(() => getBaseIdFromId(id), [id]);
@@ -68,17 +68,17 @@ export const DeleteWithi18nAction = ({ id, type, draft, published, onComplete }:
   const dialogContent = React.useMemo(() => {
     if (isConfirmDialogOpen) {
       return (
-        <ConfirmDelete
-          draft={draft}
-          published={published}
+        <ConfirmDeleteDialog
+          action='delete'
+          id={draft?._id || id}
+          type={type}
           onCancel={onDialogCancel}
           onConfirm={onDialogConfirm}
         />
       )
     }
-
     return null;
-  }, [isConfirmDialogOpen, draft, published, onDialogCancel, onDialogConfirm]);
+  }, [isConfirmDialogOpen, draft, id, type, onDialogCancel, onDialogConfirm]);
 
   return {
     onHandle,


### PR DESCRIPTION
This pull request fixes issue #124.

The `ConfirmDelete` component was renamed and refactored in @sanity/desk-tool v2.28.0. `DeleteWithi18nAction.tsx` has been updated to use the modified `ConfirmDeleteDialog` component. Appropriate props has been updated with relevant data.