### PR TITLE
fix: change `baseToTop` to actually sort base to top

### DIFF
--- a/src/input/index.tsx
+++ b/src/input/index.tsx
@@ -106,8 +106,7 @@ export const Input = React.forwardRef<any, Props>((props, ref) => {
           isBase:
             typeof baseLang?.name === "string" && lang.name === baseLang?.name,
         }))
-        .sort(baseToTop)
-        .reverse();
+        .sort(baseToTop);
 
       setLanguages(updatedSorted);
       setFetchingLanguages(false);

--- a/src/structure/components/TranslationsComponentFactory/TranslationsComponentFactory.tsx
+++ b/src/structure/components/TranslationsComponentFactory/TranslationsComponentFactory.tsx
@@ -32,18 +32,23 @@ export const TranslationsComponentFactory =
 
     React.useEffect(() => {
       (async () => {
-        const shouldReload = (languages.length === 0 || (shouldReloadFn && shouldReloadFn(draft ?? published)));
+        const shouldReload =
+          languages.length === 0 ||
+          (shouldReloadFn && shouldReloadFn(draft ?? published));
         if (shouldReload) {
           setPending(true);
           const langs = await getLanguagesFromOption(
             config.languages,
             draft ?? published
           );
-          const baseDocId = getBaseIdFromId(props.documentId)
-          const doc = await getSanityClient().fetch(`coalesce(*[_id == $draftId][0], *[_id == $id][0])`, {
-            id: baseDocId,
-            draftId: `drafts.${baseDocId}`
-          });
+          const baseDocId = getBaseIdFromId(props.documentId);
+          const doc = await getSanityClient().fetch(
+            `coalesce(*[_id == $draftId][0], *[_id == $id][0])`,
+            {
+              id: baseDocId,
+              draftId: `drafts.${baseDocId}`,
+            }
+          );
           if (doc) setBaseDocument(doc);
           setLanguages(langs);
           setPending(false);
@@ -68,8 +73,7 @@ export const TranslationsComponentFactory =
           isBase: lang.name === config.base,
           isCurrentLanguage: lang.name === currentLanguage,
         }))
-        .sort(baseToTop)
-        .reverse();
+        .sort(baseToTop);
     }, [languages, config]);
 
     if (pending) {

--- a/src/utils/baseToTop.ts
+++ b/src/utils/baseToTop.ts
@@ -1,3 +1,3 @@
 export const baseToTop = (a, b) => {
-  return a.isBase - b.isBase;
+  return b.isBase - a.isBase;
 };


### PR DESCRIPTION
By sorting base to top from the beginning we do not have to reverse the array later. This will also keep the order of the languages passed to the plugin.