### PR TITLE
fix: use calculated baseLanguage when checking which language should be the base

### DIFF
--- a/src/structure/components/TranslationsComponentFactory/TranslationsComponentFactory.tsx
+++ b/src/structure/components/TranslationsComponentFactory/TranslationsComponentFactory.tsx
@@ -65,7 +65,7 @@ export const TranslationsComponentFactory =
       return languages
         .map((lang) => ({
           ...lang,
-          isBase: lang.name === config.base,
+          isBase: typeof baseLanguage?.name === "string" && lang.name === baseLanguage?.name,
           isCurrentLanguage: lang.name === currentLanguage,
         }))
         .sort(baseToTop)


### PR DESCRIPTION
Use the same comparison as in the input component to check which language should be the base.