### PR TITLE
Set default referenceBehaviour to weak

### DIFF
--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -19,7 +19,7 @@ export function getConfig(type?: string | Ti18nSchema): Required<{
   return {
     base: schema?.base || cfg?.base || '',
     idStructure: cfg.idStructure || IdStructure.SUBPATH,
-    referenceBehavior: cfg.referenceBehavior || ReferenceBehavior.HARD,
+    referenceBehavior: cfg.referenceBehavior || ReferenceBehavior.WEAK,
     withTranslationsMaintenance: cfg?.withTranslationsMaintenance === false ? false : true,
     fieldNames: {
       lang: schema?.fieldNames?.lang || cfg?.fieldNames?.lang || '__i18n_lang',


### PR DESCRIPTION
Deleting translations sounds like a basic feature to me. Do you agree?

If the reference behaviour is Hard, you cannot delete the translations. 

Finding the default behaviour was "hard" was a bit annoying to me as a user, so I thought I might prevent people in the future from encountering the same issue :relaxed: 